### PR TITLE
Added callback and duration props to facilitate custom logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ The overlay button appears in the bottom right corner and is enabled by default.
 - `initialEnabled` (default: `true`) - Start with render scanning enabled
 - `offsetLeft` (default: `0`) - Offset the button left from its default position
 - `hideIcon` (default: `false`) - Hide the render scan button while keeping functionality active
+- `callback` (default: `undefined`) - Optional user defined function that gets called once per valid mutation. Signature is `(mutation:MutationRecord)=>void;`
+- `duration` (defult: `1000`) - Adjust how long the render scan highlights remain on screen in ms
 
 ## Development
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "svelte-render-scan",
-	"version": "1.0.5",
+	"version": "1.1.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "svelte-render-scan",
-			"version": "1.0.5",
+			"version": "1.1.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@eslint/compat": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "svelte-render-scan",
-	"version": "1.0.5",
+	"version": "1.1.0",
 	"license": "MIT",
 	"homepage": "https://khromov.github.io/svelte-render-scan/",
 	"repository": {

--- a/src/lib/components/RenderScan.svelte
+++ b/src/lib/components/RenderScan.svelte
@@ -7,11 +7,15 @@
 	let {
 		initialEnabled = true,
 		offsetLeft = 0,
-		hideIcon = false
+		hideIcon = false,
+		callback = undefined,
+		duration = 1000
 	} = $props<{
 		initialEnabled?: boolean;
 		offsetLeft?: number;
 		hideIcon?: boolean;
+		callback?: (mutationRecord: MutationRecord) => void;
+		duration?: number;
 	}>();
 
 	// State management
@@ -37,7 +41,7 @@
 </script>
 
 {#if enabled}
-	<RenderScanObserver />
+	<RenderScanObserver {callback} {duration} />
 {/if}
 
 <!-- Floating button -->

--- a/src/lib/components/RenderScanObserver.svelte
+++ b/src/lib/components/RenderScanObserver.svelte
@@ -29,10 +29,8 @@
 		get title() {
 			// Get entries once and use them for both the reasons string and total
 			const entries = [...this.#reasons.entries()];
-			const reasons = entries
-				.map(([key, count]) => `${key} (${count})`)
-				.join(' , ');
-			
+			const reasons = entries.map(([key, count]) => `${key} (${count})`).join(' , ');
+
 			// Calculate total using the same entries array
 			const total = entries.reduce((sum, [_, count]) => sum + count, 0);
 
@@ -94,7 +92,7 @@
 						this.#element.remove();
 						activeHighlights.delete(this);
 					}, 250); // Match the CSS transition duration
-				}, 1000);
+				}, duration);
 			});
 		}
 
@@ -128,6 +126,12 @@
 			};
 		}
 	}
+
+	// Props with defaults
+	let { duration = 1000, callback = undefined } = $props<{
+		duration: number;
+		callback: (mutation: MutationRecord) => void;
+	}>();
 
 	let overlayEl: HTMLDivElement | null = null;
 	let mutationObserver: MutationObserver | null = null;
@@ -185,6 +189,7 @@
 					default:
 						console.log(`Unhandled mutation type: ${mutation.type}`);
 				}
+				if (callback) callback(mutation);
 			}
 		});
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -307,7 +307,7 @@
 	</p>
 
 	{#if mounted}
-		<RenderScan />
+		<RenderScan callback={(m) => console.debug('Mutation observed!', m.type)} duration={1000} />
 	{/if}
 </div>
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -83,6 +83,12 @@
   offsetLeft={60}
 />`
 	};
+	// Callback usage code snippet
+	const callbackCode = `function customCallback(mutation: MutationRecord) {
+	// Custom code...
+}
+
+<RenderScan callback={customCallback} />`;
 </script>
 
 <div class="border-b-4 bg-[#faf6f4] py-12">
@@ -267,6 +273,22 @@
 					Hide the render scan button while keeping functionality active:
 				</p>
 				<div class="code-block">{`<RenderScan hideIcon={true} />`}</div>
+			</div>
+
+			<div>
+				<h3 class="mb-2 font-bold">Highlight Duration</h3>
+				<p class="mb-3 text-gray-600">
+					Adjust how long the render scan highlights remain on screen (default=1000):
+				</p>
+				<div class="code-block">{`<RenderScan duration={2000} />`}</div>
+			</div>
+
+			<div>
+				<h3 class="mb-2 font-bold">Callback Function</h3>
+				<p class="mb-3 text-gray-600">
+					Optional user defined function that gets called once per valid mutation:
+				</p>
+				<div class="code-block">{callbackCode}</div>
 			</div>
 
 			<div>


### PR DESCRIPTION
- Added optional `callback` prop allows a user defined function to be called for each valid mutation

- Added optional `duration` prop allows a user to set the renderscan highlight duration

- Updated the main `+page.svelte` with documentation for callback and duration options

- Updated `readme.md` with documentation for callback and duration options

- Updated minor version to 1.1.0

I didn't add a detailed example for the callback function as this started to detract from the clean simplicity of the existing code and documentation but I'm happy to provide the example of the way I am currently using it if that would help?